### PR TITLE
Wininstall [BUG FIX] Issue #199

### DIFF
--- a/resources/install.rb
+++ b/resources/install.rb
@@ -56,12 +56,20 @@ action :install do
       action :extract
     end
 
+    # Precreate 'c:\habitat to correct powershell errors'
+    # The powershell_script was just creating a file called habitat in 'c:/'
     directory 'c:\habitat'
 
     powershell_script 'installing from archive' do
       code <<-EOH
       Move-Item -Path #{Chef::Config[:file_cache_path]}/habitat/hab-*/* -Destination C:/habitat -Force
       EOH
+    end
+
+    # Cleanup for future upgrade purposes
+    directory '#{Chef::Config[:file_cache_path]}/habitat' do
+      action :delete
+      recursive true
     end
 
     # TODO: This won't self heal if missing until the next upgrade
@@ -114,13 +122,6 @@ action :upgrade do
 
     remote_file zipfile do
       source download
-    end
-
-    # TODO: Make sure "#{Chef::Config[:file_cache_path]}/habitat" doesn't already containt a previously unzipped version.
-    # My suggestion would be to delete the forlder to be safe
-    directory "#{Chef::Config[:file_cache_path]}/habitat" do
-      recursive true
-      action :delete
     end
 
     archive_file "#{package_name}.zip" do

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -17,7 +17,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 require 'chef/http/simple'
 
 resource_name :hab_install
@@ -40,7 +39,7 @@ action :install do
   if platform_family?('windows')
     # Retrieve version information
     uri = 'https://packages.chef.io/files'
-    package_name = 'hab-latest-x86_64-windows'
+    package_name = 'hab-x86_64-windows'
     zipfile = "#{Chef::Config[:file_cache_path]}/#{package_name}.zip"
 
     # TODO: Figure out how to properly validate the shasum for windows. Doesn't seem it's published
@@ -57,9 +56,11 @@ action :install do
       action :extract
     end
 
+    directory 'c:\habitat'
+
     powershell_script 'installing from archive' do
       code <<-EOH
-      Move-Item -Path #{Chef::Config[:file_cache_path]}/habitat/#{package_name} -Destination C:/habitat -Force
+      Move-Item -Path #{Chef::Config[:file_cache_path]}/habitat/hab-*/* -Destination C:/habitat -Force
       EOH
     end
 
@@ -113,6 +114,13 @@ action :upgrade do
 
     remote_file zipfile do
       source download
+    end
+
+    # TODO: Make sure "#{Chef::Config[:file_cache_path]}/habitat" doesn't already containt a previously unzipped version.
+    # My suggestion would be to delete the forlder to be safe
+    directory "#{Chef::Config[:file_cache_path]}/habitat" do
+      recursive true
+      action :delete
     end
 
     archive_file "#{package_name}.zip" do

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -1,0 +1,29 @@
+#
+# Cookbook:: habitat
+# Spec:: default
+#
+# Copyright:: 2020, The Authors, All Rights Reserved.
+
+require 'spec_helper'
+
+describe 'habitat::default' do
+  context 'When all attributes are default, on Ubuntu 18.04' do
+    # for a complete list of available platforms and versions see:
+    # https://github.com/chefspec/fauxhai/blob/master/PLATFORMS.md
+    platform 'ubuntu', '18.04'
+
+    it 'converges successfully' do
+      expect { chef_run }.to_not raise_error
+    end
+  end
+
+  context 'When all attributes are default, on CentOS 7' do
+    # for a complete list of available platforms and versions see:
+    # https://github.com/chefspec/fauxhai/blob/master/PLATFORMS.md
+    platform 'centos', '7'
+
+    it 'converges successfully' do
+      expect { chef_run }.to_not raise_error
+    end
+  end
+end

--- a/test/integration/default/default_test.rb
+++ b/test/integration/default/default_test.rb
@@ -1,0 +1,16 @@
+# InSpec test for recipe habitat::default
+
+# The InSpec reference, with examples and extensive documentation, can be
+# found at https://www.inspec.io/docs/reference/resources/
+
+unless os.windows?
+  # This is an example test, replace with your own test.
+  describe user('root'), :skip do
+    it { should exist }
+  end
+end
+
+# This is an example test, replace it with your own test.
+describe port(80), :skip do
+  it { should_not be_listening }
+end


### PR DESCRIPTION
### Description

This change correct issue with how the install resource was managing the windows install. Currently it is trying to unzip an archive that isn't named correctly. It was also trying to unzip to a directory that didn't exist so, the powershell_script block was failing silently. Also, when the archive was being moved, it was moving a folder full of files with version specific naming, this was causing the path being set to fail as well. 

- Added steps to create proper unzip directory in `c:\habitat`
- Corrected the name of the zip archive to be current
- Changed how the powershell_script block moves file so that is steps in an extra directory and the path gets set correctly. 
- Added step to clean up file_cache_path  

### Issues Resolved

Hab install fails on Windows because it can't find the directory #199

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>


```#!bin/sh
     Synchronizing Cookbooks:
         - cb_habloader (0.1.0)
         - habitat (1.5.1)
         - windows (6.0.1)
       Installing Cookbook Gems:
       Compiling Cookbooks...
       Converging 4 resources
       Recipe: cb_habloader::default
         * hab_install[install habitat] action install
           * remote_file[C:/Users/vagrant/AppData/Local/Temp/kitchen/cache/hab-x86_64-windows.zip] action create
             - create new file C:/Users/vagrant/AppData/Local/Temp/kitchen/cache/hab-x86_64-windows.zip
             - update content in file C:/Users/vagrant/AppData/Local/Temp/kitchen/cache/hab-x86_64-windows.zip from none to 344c14
             (new content is binary, diff output suppressed)
           * archive_file[hab-x86_64-windows.zip] action extract
             - create directory C:/Users/vagrant/AppData/Local/Temp/kitchen/cache/habitat
             - extract C:/Users/vagrant/AppData/Local/Temp/kitchen/cache/hab-x86_64-windows.zip to C:/Users/vagrant/AppData/Local/Temp/kitchen/cache/habitat
           * directory[c:\habitat] action create
             - create new directory c:\habitat
           * powershell_script[installing from archive] action run
             - execute "C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe" -NoLogo -NonInteractive -NoProfile -ExecutionPolicy Bypass -InputFormat None -File "C:/Users/vagrant/AppData/Local/Temp/chef-script20200207-2936-1uzte63.ps1"
           * windows_path[C:\habitat] action add
             * windows_env[path] action modify
             
           
           * execute[hab license accept] action run
             - execute hab license accept
         
         * hab_sup_windows[Test-run] action run
           * hab_install[Test-run] action install (up to date)
           * hab_package[core/hab-sup] action install
             - install version 1.5.0 of package core/hab-sup
           * hab_package[core/hab-launcher] action install
             - install version 13013 of package core/hab-launcher
           * windows_env[HAB_AUTH_TOKEN] action delete (up to date)
           * windows_env[HAB_SUP_GATEWAY_AUTH_TOKEN] action delete (up to date)
           * hab_package[core/windows-service] action install
             - install version 0.6.0 of package core/windows-service
           * execute[hab pkg exec core/windows-service install] action run (skipped due to not_if)
           * template[C:/hab/svc/windows-service/HabService.exe.config] action create
             - create new file C:/hab/svc/windows-service/HabService.exe.config
             - update content in file C:/hab/svc/windows-service/HabService.exe.config from none to 9a053c
             --- C:/hab/svc/windows-service/HabService.exe.config       2020-02-07 18:28:25.429546700 +0000
             +++ C:/hab/svc/windows-service/chef-HabService20200207-2936-8pjxds.exe.config      2020-02-07 18:28:25.429546700 +0000
             @@ -1 +1,32 @@
             +<?xml version="1.0" encoding="utf-8"?>
             +<configuration>
             +  <configSections>
             +    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net"/>
             +  </configSections>
             +  <startup>
             +    <supportedRuntime version="v4.0.30319"/>
             +  </startup>
             +  <log4net>
             +    <root>
             +      <level value="ALL" />
             +      <appender-ref ref="RollingFileAppender" />
             +    </root>
             +    <appender name="RollingFileAppender" type="log4net.Appender.RollingFileAppender">
             +      <file value="logs\Habitat.log" />
             +      <appendToFile value="true" />
             +      <rollingStyle value="Size" />
             +      <maxSizeRollBackups value="10" />
             +      <maximumFileSize value="100MB" />
             +      <staticLogFileName value="true" />
             +      <layout type="log4net.Layout.PatternLayout">
             +        <conversionPattern value="%date - %message%newline" />
             +      </layout>
             +    </appender>
             +  </log4net>
             +  <appSettings>
             +    <add key="debug" value="false" />
             +    <add key="HAB_FEAT_IGNORE_SIGNALS" value="true" />
             +    <add key="launcherArgs" value="--no-color " />
             +  </appSettings>
             +</configuration>
           * windows_service[Habitat] action enable (up to date)
           * windows_service[Habitat] action start
             - start service windows_service[Habitat]
           * windows_service[Habitat] action restart
             - restart service windows_service[Habitat]
         
       Recipe: cb_habloader::services
         * hab_package[core/7zip] action install
           - install version 16.04/20190523094208 of package core/7zip
         * hab_service[core/sqlserver] action load
           - update core/sqlserver
           -   set strategy to :"at-once" (was :none)
           * execute[hab svc load core/sqlserver --binding-mode strict --url https://bldr.habitat.sh --channel stable --group default --strategy at-once --topology standalone --health-check-interval 30 --shutdown-timeout 8 --remote-sup 127.0.0.1:9632] action run
             - execute hab svc load core/sqlserver --binding-mode strict --url https://bldr.habitat.sh --channel stable --group default --strategy at-once --topology standalone --health-check-interval 30 --shutdown-timeout 8 --remote-sup 127.0.0.1:9632
```



